### PR TITLE
﻿feat: add feature flag for tag module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,8 @@ anyhow = "1"
 url = "2"
 native-tls = "0.2"
 toml = "0.8"
+
+[features]
+default = ["tag"]
+# Future: annotated tag object support (tag create/list/delete CLI)
+tag = []

--- a/src/core/objects/mod.rs
+++ b/src/core/objects/mod.rs
@@ -1,5 +1,6 @@
 pub mod blob;
 pub mod commit;
+#[cfg(feature = "tag")]
 pub mod tag;
 pub mod tree;
 

--- a/src/core/refs.rs
+++ b/src/core/refs.rs
@@ -82,12 +82,14 @@ pub fn list_branches(repo: &Path) -> Result<Vec<String>, Box<dyn std::error::Err
 }
 
 /// 创建轻量标签（直接指向某个 commit SHA-1）。
+#[cfg(feature = "tag")]
 #[allow(dead_code)]
 pub fn create_tag(repo: &Path, name: &str, sha1: &str) -> Result<(), Box<dyn std::error::Error>> {
     write_ref(repo, &format!("refs/tags/{}", name), sha1)
 }
 
 /// 列出所有轻量标签名称。
+#[cfg(feature = "tag")]
 #[allow(dead_code)]
 pub fn list_tags(repo: &Path) -> Result<Vec<String>, Box<dyn std::error::Error>> {
     let tags_dir = refs_dir(repo).join("refs").join("tags");
@@ -96,7 +98,8 @@ pub fn list_tags(repo: &Path) -> Result<Vec<String>, Box<dyn std::error::Error>>
     }
 
     let mut tags = Vec::new();
-    let entries = fs::read_dir(&tags_dir).map_err(|e| format!("Failed to read tags dir: {}", e))?;
+    let entries =
+        fs::read_dir(&tags_dir).map_err(|e| format!("Failed to read tags dir: {}", e))?;
 
     for entry in entries {
         let entry = entry?;
@@ -108,6 +111,7 @@ pub fn list_tags(repo: &Path) -> Result<Vec<String>, Box<dyn std::error::Error>>
 }
 
 /// 删除标签。
+#[cfg(feature = "tag")]
 #[allow(dead_code)]
 pub fn delete_tag(repo: &Path, name: &str) -> Result<(), Box<dyn std::error::Error>> {
     let path = ref_path(repo, &format!("refs/tags/{}", name));
@@ -230,6 +234,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "tag")]
     fn test_create_and_list_tags() {
         let repo = setup_repo("taglist");
         setup_git_dir(&repo);
@@ -245,6 +250,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "tag")]
     fn test_list_tags_empty() {
         let repo = setup_repo("emptytags");
         setup_git_dir(&repo);
@@ -270,6 +276,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "tag")]
     fn test_delete_nonexistent_tag() {
         let repo = setup_repo("delnonex");
         setup_git_dir(&repo);


### PR DESCRIPTION
Gate tag-related code behind 	ag Cargo feature (enabled by default). This keeps the module accessible for testing while allowing opt-out via --no-default-features.

- Cargo.toml: add [features] with default = ["tag"]
- src/core/objects/mod.rs: gate pub mod tag behind #[cfg(feature = "tag")]
- src/core/refs.rs: gate create_tag/list_tags/delete_tag and their tests