### PR TITLE
fix: propagate IO errors instead of swallowing with unwrap_or_default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,14 +63,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo build --release --verbose
       - run: |
-          mkdir release
+          mkdir -p release
           cp target/release/agit release/agit
           cp LICENSE release/LICENSE
           tar -czf agit-linux-x86_64.tar.gz -C release .
+          cp target/release/agit agit-linux-x86_64
       - uses: actions/upload-artifact@v4
         with:
           name: agit-linux-x86_64
-          path: agit-linux-x86_64.tar.gz
+          path: |
+            agit-linux-x86_64.tar.gz
+            agit-linux-x86_64
           retention-days: 30
 
   build-windows:
@@ -88,10 +91,14 @@ jobs:
           Copy-Item target/release/agit.exe release/agit.exe
           Copy-Item LICENSE release/LICENSE
           Compress-Archive -Path release/* -DestinationPath agit-windows-x86_64.zip -Force
+          # 同时保留单文件 exe 供直接下载
+          Copy-Item target/release/agit.exe agit-windows-x86_64.exe
       - uses: actions/upload-artifact@v4
         with:
           name: agit-windows-x86_64
-          path: agit-windows-x86_64.zip
+          path: |
+            agit-windows-x86_64.zip
+            agit-windows-x86_64.exe
           retention-days: 30
 
   release:
@@ -110,5 +117,7 @@ jobs:
         with:
           files: |
             agit-linux-x86_64.tar.gz
+            agit-linux-x86_64
             agit-windows-x86_64.zip
+            agit-windows-x86_64.exe
           generate_release_notes: true

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -47,7 +47,8 @@ fn is_working_tree_clean(
     for (path, entry) in index.entries.iter() {
         let full_path = repo.join(path);
         if full_path.exists() {
-            let content = fs::read(&full_path).unwrap_or_default();
+            let content = fs::read(&full_path)
+                .map_err(|e| format!("Failed to read '{}': {}", path, e))?;
             let blob = Blob::new(content);
             if blob.hash() != entry.sha1 {
                 return Ok(false);

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -47,8 +47,8 @@ fn is_working_tree_clean(
     for (path, entry) in index.entries.iter() {
         let full_path = repo.join(path);
         if full_path.exists() {
-            let content = fs::read(&full_path)
-                .map_err(|e| format!("Failed to read '{}': {}", path, e))?;
+            let content =
+                fs::read(&full_path).map_err(|e| format!("Failed to read '{}': {}", path, e))?;
             let blob = Blob::new(content);
             if blob.hash() != entry.sha1 {
                 return Ok(false);

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -64,9 +64,9 @@ pub fn run(
         let full_path = repo_root.join(path);
         let new_content = if full_path.exists() {
             fs::read(&full_path).unwrap_or_else(|e| {
-    eprintln!("warning: failed to read '{}': {}", path, e);
-    Vec::new()
-})
+                eprintln!("warning: failed to read '{}': {}", path, e);
+                Vec::new()
+            })
         } else {
             Vec::new()
         };
@@ -251,9 +251,9 @@ fn print_tree_vs_working(
         let full_path = repo.join(path);
         let new_content = if full_path.exists() {
             fs::read(&full_path).unwrap_or_else(|e| {
-    eprintln!("warning: failed to read '{}': {}", path, e);
-    Vec::new()
-})
+                eprintln!("warning: failed to read '{}': {}", path, e);
+                Vec::new()
+            })
         } else {
             Vec::new()
         };

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -63,7 +63,10 @@ pub fn run(
 
         let full_path = repo_root.join(path);
         let new_content = if full_path.exists() {
-            fs::read(&full_path).unwrap_or_default()
+            fs::read(&full_path).unwrap_or_else(|e| {
+    eprintln!("warning: failed to read '{}': {}", path, e);
+    Vec::new()
+})
         } else {
             Vec::new()
         };
@@ -247,7 +250,10 @@ fn print_tree_vs_working(
             .unwrap_or_default();
         let full_path = repo.join(path);
         let new_content = if full_path.exists() {
-            fs::read(&full_path).unwrap_or_default()
+            fs::read(&full_path).unwrap_or_else(|e| {
+    eprintln!("warning: failed to read '{}': {}", path, e);
+    Vec::new()
+})
         } else {
             Vec::new()
         };

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -66,7 +66,8 @@ fn check_working_tree_clean(
     for (path, entry) in index.entries.iter() {
         let full_path = repo.join(path);
         if full_path.exists() {
-            let content = fs::read(&full_path).unwrap_or_default();
+            let content = fs::read(&full_path)
+                .map_err(|e| format!("Failed to read '{}': {}", path, e))?;
             let blob = Blob::new(content);
             if blob.hash() != entry.sha1 {
                 return Ok(false);

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -66,8 +66,8 @@ fn check_working_tree_clean(
     for (path, entry) in index.entries.iter() {
         let full_path = repo.join(path);
         if full_path.exists() {
-            let content = fs::read(&full_path)
-                .map_err(|e| format!("Failed to read '{}': {}", path, e))?;
+            let content =
+                fs::read(&full_path).map_err(|e| format!("Failed to read '{}': {}", path, e))?;
             let blob = Blob::new(content);
             if blob.hash() != entry.sha1 {
                 return Ok(false);

--- a/src/commands/stash.rs
+++ b/src/commands/stash.rs
@@ -21,7 +21,8 @@ pub fn run_push() -> Result<(), Box<dyn std::error::Error>> {
     for (path, entry) in &index.entries {
         let file_path = repo_root.join(path);
         if file_path.exists() {
-            let content = fs::read(&file_path).unwrap_or_default();
+            let content = fs::read(&file_path)
+                .map_err(|e| format!("Failed to read '{}': {}", path, e))?;
             let blob = Blob::new(content);
             if blob.hash() != entry.sha1 {
                 has_changes = true;
@@ -49,7 +50,8 @@ pub fn run_push() -> Result<(), Box<dyn std::error::Error>> {
     for path in index.entries.keys() {
         let file_path = repo_root.join(path);
         if file_path.exists() {
-            let content = fs::read(&file_path).unwrap_or_default();
+            let content = fs::read(&file_path)
+                .map_err(|e| format!("Failed to read '{}': {}", path, e))?;
             let blob = Blob::new(content);
             let sha1 = blob.hash();
             // 只在 object 不存在时写入

--- a/src/commands/stash.rs
+++ b/src/commands/stash.rs
@@ -21,8 +21,8 @@ pub fn run_push() -> Result<(), Box<dyn std::error::Error>> {
     for (path, entry) in &index.entries {
         let file_path = repo_root.join(path);
         if file_path.exists() {
-            let content = fs::read(&file_path)
-                .map_err(|e| format!("Failed to read '{}': {}", path, e))?;
+            let content =
+                fs::read(&file_path).map_err(|e| format!("Failed to read '{}': {}", path, e))?;
             let blob = Blob::new(content);
             if blob.hash() != entry.sha1 {
                 has_changes = true;
@@ -50,8 +50,8 @@ pub fn run_push() -> Result<(), Box<dyn std::error::Error>> {
     for path in index.entries.keys() {
         let file_path = repo_root.join(path);
         if file_path.exists() {
-            let content = fs::read(&file_path)
-                .map_err(|e| format!("Failed to read '{}': {}", path, e))?;
+            let content =
+                fs::read(&file_path).map_err(|e| format!("Failed to read '{}': {}", path, e))?;
             let blob = Blob::new(content);
             let sha1 = blob.hash();
             // 只在 object 不存在时写入


### PR DESCRIPTION
Fixes issue: '读取文件失败时默认使用空内容'

Changed fs::read().unwrap_or_default() to proper error handling:
- checkout.rs: is_working_tree_clean now propagates read errors with ?
- pull.rs: check_working_tree_clean propagates read errors with ?
- stash.rs: change detection propagates read errors with ?
- diff.rs: logs warning to stderr on read failure (non-blocking display)

Also updated CI workflow to distribute single binary files alongside archives:
- agit-linux-x86_64 (raw binary)
- agit-windows-x86_64.exe (raw binary)