### PR TITLE
fix: code audit fixes — error propagation, push URL, rm safety, AI guard

### DIFF
--- a/docs/audit-2025-06-14.md
+++ b/docs/audit-2025-06-14.md
@@ -1,0 +1,52 @@
+# 代码审计报告 — 2025-06-14
+
+> 全量扫描 49 个源文件、119 个测试，聚焦错误处理、边界条件、API 一致性。
+
+## 🔴 严重 (3)
+
+| # | 文件 | 行 | 描述 |
+|---|------|-----|------|
+| 1 | `src/commands/rm.rs` | 14-15 | `rm` 先删文件再检查索引 — 未跟踪文件也会被删除，与 git 行为不一致 |
+| 2 | `src/commands/push.rs` | 56-66 | `resolve_url` 检查远程 refs 目录存在后就忽略 remote name，始终推到 origin 的 URL |
+| 3 | `src/commands/commit.rs` | 79 | `.git/HEAD` 读取失败时 `unwrap_or_default()` → 静默回退到 `refs/heads/main`，commit 可能写到错误引用 |
+
+## 🟠 高 — 错误静默吞掉 (5)
+
+| # | 文件 | 行 | 描述 |
+|---|------|-----|------|
+| 4 | `src/core/remote_utils.rs` | 77 | `.git/config` 读失败 → `unwrap_or_default()` → 误导 "No remote URL" |
+| 5 | `src/core/remote_utils.rs` | 104 | HEAD 读失败 → `unwrap_or_default()` → 误导 "Not on a branch" |
+| 6 | `src/commands/remote.rs` | 9 | config 读失败 → 可能创建残缺配置文件 |
+| 7 | `src/commands/branch.rs` | 25 | `list_branches` 失败 → 静默空列表 |
+| 8 | `src/commands/reset.rs` | 17 | HEAD 读失败 → 静默空字符串 |
+| 9 | `src/commands/config_cmd.rs` | 152 | TOML 解析失败 → `unwrap_or_default()` → set/unset 覆盖时丢失全部原有数据 |
+
+## 🟡 中 (7)
+
+| # | 文件 | 行 | 描述 |
+|---|------|-----|------|
+| 10 | `src/ai/mod.rs` | 23 | `DANGEROUS_COMMANDS` 是死代码 — 定义了但从未检查 |
+| 11 | `src/ai/mod.rs` | 14 | `ai_commit_marker()` 死代码 — 定义了但从未调用 |
+| 12 | `src/commands/stash.rs` | 155-158 | stash 链表遍历无循环检测 |
+| 13 | `src/commands/diff.rs` | 399-406 | hunk header 始终 `@@ -1,N +1,N @@`，不计算真实行号 |
+| 14 | `src/commands/diff.rs` | 394 | `lines()` 剥掉尾随换行 → 尾随换行变更不可见 |
+| 15 | `src/core/protocol.rs` | 607-611 | chunked 编码检测靠 hex digit 启发 — 不可靠 |
+| 16 | `src/core/` 多处 | — | 解析失败 `unwrap_or(默认值)` 不报错 |
+
+## 🟢 低 — 代码质量 (4)
+
+| # | 文件 | 行 | 描述 |
+|---|------|-----|------|
+| 17 | `objects/mod.rs`, `checkout.rs`, `merge.rs` | — | `format_object_data` 三份重复实现 |
+| 18 | `index.rs`, `tree.rs`, `protocol.rs` | — | `hex_to_bytes` 三份重复 |
+| 19 | `refs.rs:65` vs `remote_utils.rs:103` | — | 两个 `get_current_branch` 签名不同 |
+| 20 | `src/utils/error.rs` | — | `AgitError` 枚举完整但 core 层不使用 |
+
+## ✅ 确认正常
+
+- 零 `unsafe` 块
+- 无 TODO/FIXME/HACK
+- Feature gate 正确 (`#[cfg(feature = "tag")]`)
+- 119 测试全通过
+- Config 层叠正确
+- 别名解析 (`resolve_aliases`) 正常工作

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -10,7 +10,6 @@ pub fn is_ai_mode() -> bool {
     AI_MODE.load(Ordering::SeqCst)
 }
 
-#[allow(dead_code)]
 pub fn ai_commit_marker() -> &'static str {
     if is_ai_mode() {
         "[AI-committed] "
@@ -19,5 +18,31 @@ pub fn ai_commit_marker() -> &'static str {
     }
 }
 
-#[allow(dead_code)]
-pub const DANGEROUS_COMMANDS: &[&str] = &["mergetool", "rebase", "bisect"];
+/// AI 模式下禁止执行的破坏性命令列表。
+pub const DANGEROUS_COMMANDS: &[&str] = &[
+    "mergetool",
+    "rebase",
+    "bisect",
+    "push",       // 可能推送到远程
+    "stash drop", // 删除暂存
+    "branch -D",  // 强制删除分支
+];
+
+/// 检查命令是否为 AI 模式下的危险命令。
+/// 在 AI 模式下返回 Err 阻止执行；非 AI 模式始终返回 Ok。
+pub fn check_dangerous_command(command: &str) -> Result<(), Box<dyn std::error::Error>> {
+    if !is_ai_mode() {
+        return Ok(());
+    }
+    let cmd_lower = command.to_lowercase();
+    for dangerous in DANGEROUS_COMMANDS {
+        if cmd_lower.contains(dangerous) {
+            return Err(format!(
+                "AI mode: '{}' is a dangerous command and is blocked. Use --ai flag explicitly to override.",
+                command
+            )
+            .into());
+        }
+    }
+    Ok(())
+}

--- a/src/commands/branch.rs
+++ b/src/commands/branch.rs
@@ -17,15 +17,18 @@ pub fn run(
     }
 
     // 默认：列出所有分支
-    list_branches_action(&repo_root, &current);
-    Ok(())
+    list_branches_action(&repo_root, &current)
 }
 
-fn list_branches_action(repo: &std::path::Path, current: &Option<String>) {
-    let branches = refs::list_branches(repo).unwrap_or_default();
+fn list_branches_action(
+    repo: &std::path::Path,
+    current: &Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let branches =
+        refs::list_branches(repo).map_err(|e| format!("Failed to list branches: {}", e))?;
     if branches.is_empty() {
         println!("(no branches)");
-        return;
+        return Ok(());
     }
     for b in &branches {
         if current.as_deref() == Some(b) {
@@ -34,6 +37,7 @@ fn list_branches_action(repo: &std::path::Path, current: &Option<String>) {
             println!("  {}", b);
         }
     }
+    Ok(())
 }
 
 fn create_branch_action(

--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -46,7 +46,7 @@ pub fn run(message: Option<String>, ai_flag: bool) -> Result<(), Box<dyn std::er
     };
 
     if is_ai {
-        msg = format!("[AI-committed] {}", msg);
+        msg = format!("{}{}", ai::ai_commit_marker(), msg);
     }
     if !msg.ends_with('\n') {
         msg.push('\n');
@@ -75,15 +75,17 @@ pub fn run(message: Option<String>, ai_flag: bool) -> Result<(), Box<dyn std::er
     let commit_sha1 = commit.hash();
     storage::write_object(&repo_root, "commit", &commit.serialize_raw())?;
 
-    let head_content =
-        std::fs::read_to_string(repo_root.join(".git").join("HEAD")).unwrap_or_default();
+    let head_content = std::fs::read_to_string(repo_root.join(".git").join("HEAD"))
+        .map_err(|e| format!("Failed to read HEAD: {}", e))?;
     let head_trimmed = head_content.trim();
     let branch_ref = if let Some(ref_path) = head_trimmed.strip_prefix("ref: ") {
         ref_path.trim().to_string()
     } else if head_trimmed.len() == 40 && head_trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
         return Err("You are in 'detached HEAD' state. Please create a branch first.".into());
+    } else if head_trimmed.is_empty() {
+        return Err("HEAD is empty or corrupted. Cannot determine current branch.".into());
     } else {
-        "refs/heads/main".to_string()
+        return Err(format!("Unexpected HEAD content: '{}'", head_trimmed).into());
     };
     refs::write_ref(&repo_root, &branch_ref, &commit_sha1)?;
 

--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -44,7 +44,7 @@ fn resolve_config_path(global: bool) -> Result<PathBuf, Box<dyn std::error::Erro
 
 /// 列出所有配置项。
 fn list_config(config_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
-    let table = read_toml(config_path);
+    let table = read_toml(config_path).unwrap_or_default();
     if table.is_empty() {
         // 即使文件不存在也输出默认配置的键值
         println!("user.name=agit");
@@ -70,7 +70,7 @@ fn list_config(config_path: &std::path::Path) -> Result<(), Box<dyn std::error::
 fn get_key(config_path: &std::path::Path, key: &str) -> Result<(), Box<dyn std::error::Error>> {
     let (section, field) = parse_key(key)?;
 
-    let table = read_toml(config_path);
+    let table = read_toml(config_path).unwrap_or_default();
     if let Some(section_val) = table.get(&section) {
         if let Some(inner) = section_val.as_table() {
             if let Some(val) = inner.get(&field) {
@@ -100,7 +100,7 @@ fn set_key(
     value: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (section, field) = parse_key(key)?;
-    let mut table = read_toml(config_path);
+    let mut table = read_toml(config_path)?;
 
     // 插入或更新 section.field = value
     let inner = table
@@ -117,7 +117,7 @@ fn set_key(
 /// 删除配置项。
 fn unset_key(config_path: &std::path::Path, key: &str) -> Result<(), Box<dyn std::error::Error>> {
     let (section, field) = parse_key(key)?;
-    let mut table = read_toml(config_path);
+    let mut table = read_toml(config_path)?;
 
     if let Some(section_val) = table.get_mut(&section) {
         if let Some(t) = section_val.as_table_mut() {
@@ -147,10 +147,19 @@ fn parse_key(key: &str) -> Result<(String, String), Box<dyn std::error::Error>> 
 }
 
 /// 读取 TOML 文件返回 table Map。
-fn read_toml(path: &std::path::Path) -> Map<String, toml::Value> {
+/// 文件不存在时返回空 Map；I/O 错误和 TOML 解析错误向上传播。
+fn read_toml(
+    path: &std::path::Path,
+) -> Result<Map<String, toml::Value>, Box<dyn std::error::Error>> {
     match fs::read_to_string(path) {
-        Ok(content) => toml::from_str(&content).unwrap_or_default(),
-        Err(_) => Map::new(),
+        Ok(content) => {
+            if content.trim().is_empty() {
+                return Ok(Map::new());
+            }
+            toml::from_str(&content).map_err(|e| format!("Failed to parse config: {}", e).into())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Map::new()),
+        Err(e) => Err(format!("Failed to read config file: {}", e).into()),
     }
 }
 

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -66,5 +66,5 @@ fn resolve_url(
     if let Some(u) = url {
         return Ok(u.to_string());
     }
-    remote_utils::get_remote_url(repo)
+    remote_utils::get_remote_url(repo, None)
 }

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -9,7 +9,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
     let repo_root = repo::find_repo_root()?;
 
     let branch = remote_utils::get_current_branch(&repo_root)?;
-    let remote_url = remote_utils::get_remote_url(&repo_root)?;
+    let remote_url = remote_utils::get_remote_url(&repo_root, None)?;
 
     let index = Index::load(&repo_root)?;
     let working_clean = check_working_tree_clean(&repo_root, &index)?;

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -53,17 +53,7 @@ fn resolve_url(
     repo: &std::path::Path,
     remote: Option<&str>,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    if let Some(remote_name) = remote {
-        let refs_path = repo
-            .join(".git")
-            .join("refs")
-            .join("remotes")
-            .join(remote_name);
-        if !refs_path.exists() {
-            return Err(format!("remote '{}' not found", remote_name).into());
-        }
-    }
-    remote_utils::get_remote_url(repo)
+    remote_utils::get_remote_url(repo, remote)
 }
 
 fn resolve_branch(

--- a/src/commands/remote.rs
+++ b/src/commands/remote.rs
@@ -6,7 +6,11 @@ pub fn run_add(name: &str, url: &str) -> Result<(), Box<dyn std::error::Error>> 
     let repo_root = repo::find_repo_root()?;
     let config_path = repo_root.join(".git").join("config");
 
-    let mut config = fs::read_to_string(&config_path).unwrap_or_default();
+    let mut config = match fs::read_to_string(&config_path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(format!("Failed to read .git/config: {}", e).into()),
+    };
 
     let section = format!(
         "[remote \"{}\"]\n\turl = {}\n\tfetch = +refs/heads/*:refs/remotes/{}/*\n",

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -14,7 +14,8 @@ pub fn run(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let repo_root = repo::find_repo_root()?;
 
-    let head_sha = refs::read_head(&repo_root).unwrap_or_default();
+    let head_sha =
+        refs::read_head(&repo_root).map_err(|e| format!("Failed to read HEAD: {}", e))?;
 
     // 如果指定了文件路径，执行 unstage 模式
     if !files.is_empty() {

--- a/src/commands/rm.rs
+++ b/src/commands/rm.rs
@@ -11,19 +11,21 @@ pub fn run(cached: bool, files: &[String]) -> Result<(), Box<dyn std::error::Err
     for file in files {
         let full_path = repo_root.join(file);
 
+        // 先检查是否在索引中，未跟踪的文件拒绝删除（与 git 行为一致）
+        if !index.entries.contains_key(file) {
+            eprintln!("error: '{}' not tracked", file);
+            continue;
+        }
+
+        // 从索引中删除
+        index.remove_entry(file);
+
+        // 非 cached 模式从工作区删除文件
         if !cached && full_path.exists() {
             fs::remove_file(&full_path)?;
         }
 
-        if index.entries.contains_key(file) {
-            index.remove_entry(file);
-            println!("rm '{}'", file);
-        } else if !cached && full_path.exists() {
-            // 即使不在 index 中也删除了工作区文件
-            println!("rm '{}'", file);
-        } else {
-            eprintln!("error: '{}' not tracked", file);
-        }
+        println!("rm '{}'", file);
     }
 
     index.save(&repo_root)?;

--- a/src/core/remote_utils.rs
+++ b/src/core/remote_utils.rs
@@ -73,8 +73,12 @@ pub fn apply_tree_by_sha1(
     apply_tree(repo, prefix, &tree)
 }
 
-pub fn get_remote_url(repo: &Path) -> Result<String, Box<dyn std::error::Error>> {
-    let config = fs::read_to_string(repo.join(".git").join("config")).unwrap_or_default();
+pub fn get_remote_url(
+    repo: &Path,
+    remote_name: Option<&str>,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let config = fs::read_to_string(repo.join(".git").join("config"))
+        .map_err(|e| format!("Failed to read .git/config: {}", e))?;
     let mut current_section = "";
     let mut first_url: Option<String> = None;
 
@@ -88,20 +92,34 @@ pub fn get_remote_url(repo: &Path) -> Result<String, Box<dyn std::error::Error>>
         } else if trimmed.starts_with('[') {
             current_section = "";
         } else if let Some(url) = trimmed.strip_prefix("url = ") {
-            if current_section == "origin" {
-                return Ok(url.to_string());
-            }
-            if first_url.is_none() {
-                first_url = Some(url.to_string());
+            // 如果指定了 remote name，精确匹配
+            if let Some(target) = remote_name {
+                if current_section == target {
+                    return Ok(url.to_string());
+                }
+            } else {
+                // 未指定时优先 "origin"，否则取第一个
+                if current_section == "origin" {
+                    return Ok(url.to_string());
+                }
+                if first_url.is_none() {
+                    first_url = Some(url.to_string());
+                }
             }
         }
+    }
+
+    // 指定名称时未找到匹配的 remote
+    if let Some(name) = remote_name {
+        return Err(format!("remote '{}' not found in config", name).into());
     }
 
     first_url.ok_or_else(|| "No remote URL configured".into())
 }
 
 pub fn get_current_branch(repo: &Path) -> Result<String, Box<dyn std::error::Error>> {
-    let head_content = fs::read_to_string(repo.join(".git").join("HEAD")).unwrap_or_default();
+    let head_content = fs::read_to_string(repo.join(".git").join("HEAD"))
+        .map_err(|e| format!("Failed to read HEAD: {}", e))?;
     let head_content = head_content.trim();
     if let Some(ref_path) = head_content.strip_prefix("ref: ") {
         ref_path

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,14 @@ fn main() {
     output::set_yaml_mode(cli.yaml);
     output::set_no_color(cli.no_color);
 
+    // AI 模式下检查危险命令
+    if let Some(ref cmd) = cli.command {
+        if let Err(e) = ai::check_dangerous_command(&command_name(cmd)) {
+            eprintln!("error: {}", e);
+            std::process::exit(1);
+        }
+    }
+
     let result = match &cli.command {
         None => {
             println!("agit - AI-native Git tool (Pure Rust)");
@@ -116,6 +124,33 @@ fn main() {
     if let Err(e) = result {
         eprintln!("error: {}", e);
         std::process::exit(1);
+    }
+}
+
+/// 将 Commands 枚举转为字符串表示，用于危险命令检查（如 "push"、"stash drop"）。
+fn command_name(cmd: &Commands) -> String {
+    match cmd {
+        Commands::Push { .. } => "push".to_string(),
+        Commands::Stash { action } => match action {
+            StashAction::Push => "stash push".to_string(),
+            StashAction::Pop => "stash pop".to_string(),
+            StashAction::List => "stash list".to_string(),
+            StashAction::Drop { .. } => "stash drop".to_string(),
+        },
+        Commands::Reset { .. } => "reset".to_string(),
+        Commands::Branch { delete, .. } => {
+            if delete.is_some() {
+                "branch -D".to_string()
+            } else {
+                "branch".to_string()
+            }
+        }
+        Commands::Merge { .. } => "merge".to_string(),
+        Commands::Tag { action } => match action {
+            TagAction::Delete { .. } => "tag -d".to_string(),
+            _ => "tag".to_string(),
+        },
+        _ => "".to_string(),
     }
 }
 


### PR DESCRIPTION
  ## 概览

  基于 2025-06-14 代码审计的修复（详见 `docs/audit-2025-06-14.md`）。

  ## 提交

  | Commit | 描述 |
  |--------|------|
  | `fix(rm)` | 先检查索引再删文件，拒绝删除未跟踪文件 |
  | `fix(push)` | 按 remote name 解析 URL，不再总是推到 origin |
  | `fix:` | 传播 I/O 错误，替换 6 处 `unwrap_or_default()` 吞错 |
  | `feat(ai)` | AI 模式危险命令守卫（push、stash drop、branch -D 等） |
  | `docs:` | 添加完整审计报告 |

  ## 质量门

  - ✅ 119 测试全通过
  - ✅ `cargo clippy` 0 警告
  - ✅ `cargo fmt` 无差异
  - ✅ 13 文件，+193 / -51