### PR TITLE
chore: bump version to 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to AdapterGit (agit) will be documented in this file.
 
 ---
 
-## [v0.13.0] — Unreleased
+## [v0.13.0] — 2026-06-21
 
 > 双版本分发 + AI 提交 — Dual-Edition Distribution & AI Commit
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agit"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "AI-native Git tool - pure Rust implementation"
 license = "Apache-2.0"

--- a/TODO.md
+++ b/TODO.md
@@ -156,5 +156,5 @@ AdapterGit 项目待办事项清单。最后更新: 2026-06-20 (v0.10.0 开发�
 | **v0.10.0** | **SSH 传输协议** | ✅ **已发布** | SSH 传输 (子进程), Transport trait |
 | **v0.11.0** | **Blame + Reflog** | ✅ **已发布** | blame, reflog, 103 单元测试 |
 | **v0.12.0** | **Bisect** | ✅ **已发布** | bisect (start/good/bad/skip/reset/log/run), 109 单元测试 |
-| **v0.13.0** | **双版本分发 + AI 提交** | 🚀 **当前** | lite/full, musl, .deb, macOS, Docker, LLM commit |
+| **v0.13.0** | **双版本分发 + AI 提交** | ✅ **已发布** | lite/full, musl, .deb, macOS, Docker, LLM commit |
 | v1.0.0 | 完整 Git 子集 + 全平台分发 | 🏁 目标 | 全命令覆盖 + 多平台安装包 |


### PR DESCRIPTION
Release v0.13.0: dual-edition distribution + AI commit.