### PR TITLE
fix: 6 high-priority bugfixes from code review

### DIFF
--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -1,8 +1,9 @@
 use crate::core::index::Index;
-use crate::core::{checkout, refs, repo};
+use crate::core::{checkout, reflog, refs, repo};
 
 pub fn run(branch: &str, force: bool) -> Result<(), Box<dyn std::error::Error>> {
     let repo_root = repo::find_repo_root()?;
+    let cfg = crate::config::load();
 
     // 检查分支是否存在
     let ref_path = format!("refs/heads/{}", branch);
@@ -34,5 +35,18 @@ pub fn run(branch: &str, force: bool) -> Result<(), Box<dyn std::error::Error>> 
         }
     }
 
-    checkout::switch_branch(&repo_root, branch)
+    let old_head = refs::read_head(&repo_root)
+        .unwrap_or_else(|_| "0000000000000000000000000000000000000000".into());
+    checkout::switch_branch(&repo_root, branch)?;
+    let new_head = refs::read_head(&repo_root)?;
+    let _ = reflog::append_reflog(
+        &repo_root,
+        "HEAD",
+        &old_head,
+        &new_head,
+        &cfg.user_name,
+        &format!("checkout: moving to {}", branch),
+    );
+
+    Ok(())
 }

--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -4,6 +4,7 @@ use crate::core::index::Index;
 use crate::core::objects::blob::Blob;
 use crate::core::objects::commit::Commit;
 use crate::core::objects::tree::Tree;
+use crate::core::reflog;
 use crate::core::refs;
 use crate::core::repo;
 use crate::core::storage;
@@ -95,6 +96,16 @@ pub fn run(message: Option<String>, ai_flag: bool) -> Result<(), Box<dyn std::er
         let in_cherry_pick = git_dir.join("CHERRY_PICK_TODO").exists();
         if in_rebase || in_cherry_pick {
             // 直接写入 HEAD（不更新分支引用）
+            let old_head = refs::read_head(&repo_root)
+                .unwrap_or_else(|_| "0000000000000000000000000000000000000000".into());
+            let _ = reflog::append_reflog(
+                &repo_root,
+                "HEAD",
+                &old_head,
+                &commit_sha1,
+                &cfg.user_name,
+                &format!("commit: {}", msg.trim()),
+            );
             refs::write_head(&repo_root, &commit_sha1)?;
             let parent_info = if commit.parents.is_empty() {
                 " (root-commit)"
@@ -113,7 +124,25 @@ pub fn run(message: Option<String>, ai_flag: bool) -> Result<(), Box<dyn std::er
     } else {
         return Err(format!("Unexpected HEAD content: '{}'", head_trimmed).into());
     };
+    let old_head = refs::read_head(&repo_root)
+        .unwrap_or_else(|_| "0000000000000000000000000000000000000000".into());
     refs::write_ref(&repo_root, &branch_ref, &commit_sha1)?;
+    let _ = reflog::append_reflog(
+        &repo_root,
+        "HEAD",
+        &old_head,
+        &commit_sha1,
+        &cfg.user_name,
+        &format!("commit: {}", msg.trim()),
+    );
+    let _ = reflog::append_reflog(
+        &repo_root,
+        &branch_ref,
+        &old_head,
+        &commit_sha1,
+        &cfg.user_name,
+        &format!("commit: {}", msg.trim()),
+    );
 
     // 清理合并状态文件
     if in_merge {

--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -79,8 +79,13 @@ pub fn run(message: Option<String>, ai_flag: bool) -> Result<(), Box<dyn std::er
     let commit_sha1 = commit.hash();
     storage::write_object(&repo_root, "commit", &commit.serialize_raw())?;
 
-    let head_content = std::fs::read_to_string(repo_root.join(".git").join("HEAD"))
-        .map_err(|e| format!("Failed to read HEAD: {}", e))?;
+    let head_path = repo_root.join(".git").join("HEAD");
+    let head_content = if head_path.exists() {
+        std::fs::read_to_string(&head_path)?
+    } else {
+        // 新仓库，HEAD 尚未创建 → 初始化为 main
+        String::new()
+    };
     let head_trimmed = head_content.trim();
     let branch_ref = if let Some(ref_path) = head_trimmed.strip_prefix("ref: ") {
         ref_path.trim().to_string()
@@ -101,7 +106,10 @@ pub fn run(message: Option<String>, ai_flag: bool) -> Result<(), Box<dyn std::er
         }
         return Err("You are in 'detached HEAD' state. Please create a branch first.".into());
     } else if head_trimmed.is_empty() {
-        return Err("HEAD is empty or corrupted. Cannot determine current branch.".into());
+        // HEAD 为空：初始化默认分支 main（首次 commit）
+        let default_branch = "ref: refs/heads/main";
+        refs::write_head(&repo_root, default_branch)?;
+        "refs/heads/main".to_string()
     } else {
         return Err(format!("Unexpected HEAD content: '{}'", head_trimmed).into());
     };

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -59,7 +59,10 @@ pub fn run(
         let old_content = head_tree_map
             .get(path)
             .and_then(|sha1| read_blob_content(&repo_root, sha1))
-            .unwrap_or_default();
+            .unwrap_or_else(|| {
+                eprintln!("warning: failed to read blob for '{}' in HEAD tree", path);
+                Vec::new()
+            });
 
         let full_path = repo_root.join(path);
         let new_content = if full_path.exists() {
@@ -90,8 +93,11 @@ pub fn run(
                 if name_only {
                     println!("{}", path);
                 } else {
-                    let old_content =
-                        read_blob_content(&repo_root, &head_tree_map[path]).unwrap_or_default();
+                    let old_content = read_blob_content(&repo_root, &head_tree_map[path])
+                        .unwrap_or_else(|| {
+                            eprintln!("warning: failed to read blob for '{}'", path);
+                            Vec::new()
+                        });
                     let a_path = format!("a/{}", path);
                     let b_path = format!("b/{}", path);
                     let diff = generate_unified_diff_deleted(&a_path, &b_path, &old_content);
@@ -204,11 +210,17 @@ fn print_tree_diff(
         let content1 = map1
             .get(path)
             .and_then(|s| read_blob_content(repo, s))
-            .unwrap_or_default();
+            .unwrap_or_else(|| {
+                eprintln!("warning: failed to read blob for '{}' in tree1", path);
+                Vec::new()
+            });
         let content2 = map2
             .get(path)
             .and_then(|s| read_blob_content(repo, s))
-            .unwrap_or_default();
+            .unwrap_or_else(|| {
+                eprintln!("warning: failed to read blob for '{}' in tree2", path);
+                Vec::new()
+            });
 
         if content1 != content2 {
             if name_only {
@@ -247,7 +259,10 @@ fn print_tree_vs_working(
         let old_content = tree_map
             .get(path)
             .and_then(|s| read_blob_content(repo, s))
-            .unwrap_or_default();
+            .unwrap_or_else(|| {
+                eprintln!("warning: failed to read blob for '{}' in tree", path);
+                Vec::new()
+            });
         let full_path = repo.join(path);
         let new_content = if full_path.exists() {
             fs::read(&full_path).unwrap_or_else(|e| {

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -1,5 +1,5 @@
 use crate::config;
-use crate::core::{checkout, merge, refs, repo};
+use crate::core::{checkout, merge, reflog, refs, repo};
 use std::fs;
 
 pub fn run(
@@ -47,7 +47,19 @@ pub fn run(
         cfg.user_name, cfg.user_email, timestamp, time_str
     );
 
-    merge::merge_branch(&repo_root, branch, &author, &author)
+    let old_head = refs::read_head(&repo_root)
+        .unwrap_or_else(|_| "0000000000000000000000000000000000000000".into());
+    merge::merge_branch(&repo_root, branch, &author, &author)?;
+    let new_head = refs::read_head(&repo_root)?;
+    let _ = reflog::append_reflog(
+        &repo_root,
+        "HEAD",
+        &old_head,
+        &new_head,
+        &cfg.user_name,
+        &format!("merge {}: {}", branch, branch),
+    );
+    Ok(())
 }
 
 /// 中止正在进行的合并，恢复到合并前的状态。

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -1,7 +1,7 @@
 use crate::core::index::Index;
 use crate::core::objects::commit::Commit;
 use crate::core::objects::tree::Tree;
-use crate::core::{checkout, refs, repo, storage};
+use crate::core::{checkout, reflog, refs, repo, storage};
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -39,6 +39,7 @@ pub fn run(
         }
     };
 
+    let old_head = head_sha.clone();
     if hard {
         reset_hard(&repo_root, &target_sha)?;
     } else if soft {
@@ -47,6 +48,16 @@ pub fn run(
         // --mixed 为默认行为
         reset_mixed(&repo_root, &target_sha)?;
     }
+
+    let cfg = crate::config::load();
+    let _ = reflog::append_reflog(
+        &repo_root,
+        "HEAD",
+        &old_head,
+        &target_sha,
+        &cfg.user_name,
+        &format!("reset: moving to {}", &target_sha[..7]),
+    );
 
     Ok(())
 }

--- a/src/core/checkout.rs
+++ b/src/core/checkout.rs
@@ -72,7 +72,11 @@ fn rebuild_index_from_tree(
         if entry.mode == "40000" {
             rebuild_index_from_tree(repo, &entry.sha1, &entry_path, idx)?;
         } else {
-            idx.add_entry(&entry.mode, &entry.sha1, &entry_path.to_string_lossy());
+            idx.add_entry(
+                &entry.mode,
+                &entry.sha1,
+                &entry_path.to_string_lossy().replace('\\', "/"),
+            );
         }
     }
     Ok(())
@@ -153,7 +157,11 @@ fn restore_tree(
                 }
                 fs::write(&file_path, &blob.content)?;
 
-                new_index.add_entry(&entry.mode, &entry.sha1, &entry_path.to_string_lossy());
+                new_index.add_entry(
+                    &entry.mode,
+                    &entry.sha1,
+                    &entry_path.to_string_lossy().replace('\\', "/"),
+                );
             }
         }
     }
@@ -190,7 +198,7 @@ fn collect_tree_paths(
 
     for entry in &tree.entries {
         let entry_path = prefix.join(&entry.name);
-        let path_str = entry_path.to_string_lossy().to_string();
+        let path_str = entry_path.to_string_lossy().replace('\\', "/");
 
         if entry.mode == "40000" {
             let sub = collect_tree_paths(repo, &entry.sha1, &entry_path)?;

--- a/src/core/merge.rs
+++ b/src/core/merge.rs
@@ -320,7 +320,7 @@ fn read_tree_files_recursive(
             files.extend(sub);
         } else {
             files.insert(
-                entry_path.to_string_lossy().to_string(),
+                entry_path.to_string_lossy().replace('\\', "/"),
                 FileInfo {
                     sha1: entry.sha1.clone(),
                     mode: entry.mode.clone(),
@@ -425,7 +425,7 @@ fn collect_tree_paths(
 
     for entry in &tree.entries {
         let entry_path = prefix.join(&entry.name);
-        let path_str = entry_path.to_string_lossy().to_string();
+        let path_str = entry_path.to_string_lossy().replace('\\', "/");
 
         if entry.mode == "40000" {
             let sub = collect_tree_paths(repo, &entry.sha1, &entry_path)?;
@@ -493,7 +493,11 @@ fn restore_tree_recursive(
                 fs::create_dir_all(parent)?;
             }
             fs::write(&file_path, &blob.content)?;
-            idx.add_entry(&entry.mode, &entry.sha1, &entry_path.to_string_lossy());
+            idx.add_entry(
+                &entry.mode,
+                &entry.sha1,
+                &entry_path.to_string_lossy().replace('\\', "/"),
+            );
         }
     }
     Ok(())

--- a/src/core/repo.rs
+++ b/src/core/repo.rs
@@ -37,7 +37,71 @@ pub fn get_current_timestamp() -> (i64, String) {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default();
     let timestamp = now.as_secs() as i64;
-    (timestamp, format!("{} +0800", timestamp))
+    let tz = local_tz_offset();
+    (timestamp, format!("{} {}", timestamp, tz))
+}
+
+/// 获取本地时区偏移字符串（如 "+0800"）。
+fn local_tz_offset() -> String {
+    // 使用 time() + localtime() 计算 UTC 偏移
+    // 这两个函数在所有主流平台均可使用
+    extern "C" {
+        fn time(t: *mut i64) -> i64;
+        fn localtime(t: *const i64) -> *mut CTime;
+    }
+
+    #[repr(C)]
+    struct CTime {
+        tm_sec: i32,
+        tm_min: i32,
+        tm_hour: i32,
+        tm_mday: i32,
+        tm_mon: i32,
+        tm_year: i32,
+        tm_wday: i32,
+        tm_yday: i32,
+        tm_isdst: i32,
+        #[cfg(not(target_os = "windows"))]
+        tm_gmtoff: i64,
+        #[cfg(not(target_os = "windows"))]
+        tm_zone: *const u8,
+    }
+
+    unsafe {
+        let mut now: i64 = 0;
+        time(&mut now);
+        let tm = localtime(&now);
+        if tm.is_null() {
+            return "+0000".to_string();
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            let offset = (*tm).tm_gmtoff;
+            let hours = offset / 3600;
+            let mins = (offset.abs() % 3600) / 60;
+            format!("{:+03}{:02}", hours, mins)
+        }
+        #[cfg(target_os = "windows")]
+        {
+            // Windows 没有 tm_gmtoff，用 TIME_ZONE_INFORMATION 替代
+            use std::mem::zeroed;
+            #[repr(C)]
+            struct TimeZoneInfo {
+                bias: i32,
+                _rest: [u16; 42],
+            }
+            extern "system" {
+                fn GetTimeZoneInformation(tz: *mut TimeZoneInfo) -> u32;
+            }
+            let mut tz: TimeZoneInfo = zeroed();
+            GetTimeZoneInformation(&mut tz);
+            // bias 是 UTC = local + bias (分钟)，所以 offset = -bias
+            let offset_min = -tz.bias;
+            let hours = offset_min / 60;
+            let mins = offset_min.abs() % 60;
+            format!("{:+03}{:02}", hours, mins)
+        }
+    }
 }
 
 /// 解析 commit/tree-ish 引用为完整 SHA-1。

--- a/src/core/ssh_transport.rs
+++ b/src/core/ssh_transport.rs
@@ -69,10 +69,11 @@ impl SshTransport {
 
         // 写入输入
         if !input.is_empty() {
-            child
+            let stdin = child
                 .stdin
                 .as_mut()
-                .unwrap()
+                .ok_or("SSH stdin pipe not available (process may have exited)")?;
+            stdin
                 .write_all(input)
                 .map_err(|e| format!("Failed to write to ssh stdin: {}", e))?;
             // 关闭 stdin 以告知对方输入结束
@@ -81,10 +82,11 @@ impl SshTransport {
 
         // 读取输出
         let mut output = Vec::new();
-        child
+        let stdout = child
             .stdout
             .as_mut()
-            .unwrap()
+            .ok_or("SSH stdout pipe not available (process may have exited)")?;
+        stdout
             .read_to_end(&mut output)
             .map_err(|e| format!("Failed to read ssh stdout: {}", e))?;
 


### PR DESCRIPTION
## 修复的 6 个高位问题

1. **时区硬编码** — `get_current_timestamp()` 现在使用系统本地时区
2. **SSH unwrap panic** — `ssh_transport.rs` stdin/stdout 改为 `ok_or()`
3. **首次 commit 被拒绝** — HEAD 为空/缺失时自动初始化 main 分支
4. **diff 静默吞错** — 5 处 `unwrap_or_default()` 改为 `unwrap_or_else()` + warning
5. **Windows 路径反斜杠** — checkout/merge 的 6 处 index 路径加 `replace('\', '/')`
6. **reflog 从未写入** — commit/checkout/reset/merge 全部集成 reflog 写入

## Quality Gate

| Check | Result |
|-------|--------|
| cargo build | 0 errors |
| cargo clippy | 1 warning (pre-existing `build_staged_summary` dead_code) |
| cargo test | 178 passed |