### PR TITLE
chore: bump version to 0.13.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agit"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 description = "AI-native Git tool - pure Rust implementation"
 license = "Apache-2.0"


### PR DESCRIPTION
Release v0.13.1: LLM config + 6 bugfixes + safe timezone